### PR TITLE
fix:i18n set default support language

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,5 +10,5 @@ export const Strings = stringsConfigJson.strings;
 
 export const t = (field: ILanguageField) => {
   const lang = getLanguage().replace('-', '_');
-  return field[lang];
+  return field[lang] || field['en_US'];
 };


### PR DESCRIPTION
English is used by default to prevent the widget from crashing in other languages