### PR TITLE
feat: exclude zero point in charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,22 +27,23 @@
     "react-dom": "*"
   },
   "devDependencies": {
-    "eslint": "7.32.0",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
+    "eslint": "7.32.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-vika": "0.0.1"
   },
   "dependencies": {
     "@antv/g2plot": "^2.3.39",
-    "@rjsf/core": "^2.4.0",
-    "@types/react": "^16.9.43",
-    "@types/react-dom": "^16.9.8",
     "@apitable/components": "latest",
     "@apitable/core": "latest",
     "@apitable/icons": "latest",
     "@apitable/widget-sdk": "^0.0.2",
+    "@rjsf/core": "^2.4.0",
+    "@types/react": "^16.9.43",
+    "@types/react-dom": "^16.9.8",
+    "ahooks": "^3.7.8",
     "dayjs": "^1.10.4",
     "echarts": "^5.3.1",
     "lodash": "^4.17.20",

--- a/src/model/echarts_base.ts
+++ b/src/model/echarts_base.ts
@@ -285,6 +285,11 @@ export abstract class EchartsBase {
         type: 'boolean',
         description: t(Strings.show_data_tips_describle),
       },
+      excludeZeroPoint: {
+        title: t(Strings.exclude_zero_point),
+        type: 'boolean',
+        description: t(Strings.exclude_zero_point_describle),
+      },
       theme: {
         title: t(Strings.select_theme_color),
         type: 'string',

--- a/src/model/echarts_column.ts
+++ b/src/model/echarts_column.ts
@@ -146,7 +146,7 @@ export class EchartsColumn extends EchartsBase {
     
     const isColumn = this.type === ChartType.EchartsColumn;
     const isPercent = this.stackType === StackType.Percent
-    const { axisSortType, isCountNullValue } = chartStyle;
+    const { axisSortType, isCountNullValue, excludeZeroPoint } = chartStyle;
     const dimensionMetricsMap = this.getFormDimensionMetricsMap();
     const yKey = dimensionMetricsMap.metrics.key;
     // Statistical dimension attribute, statistical value attribute, statistical value name.
@@ -244,7 +244,7 @@ export class EchartsColumn extends EchartsBase {
     const subPercentAxis = isPercent ? { max: 100 } : {};
 
     const mainAxis = { ...mainAxisOption };
-    const subAxis = { ...subAxisOption, ...subPercentAxis };
+    const subAxis = { ...subAxisOption, ...subPercentAxis, scale: excludeZeroPoint };
 
     const options = {
       ...styleOption.commonOption,

--- a/src/model/echarts_line.ts
+++ b/src/model/echarts_line.ts
@@ -103,7 +103,7 @@ export class EchartsLine extends EchartsBase {
     const { seriesField, dimension, metrics, metricsType, isSplitMultipleValue,
       isFormatDatetime: _isFormatDatetime, datetimeFormatter } = chartStructure;
     
-    const { axisSortType, isCountNullValue } = chartStyle;
+    const { axisSortType, isCountNullValue, excludeZeroPoint } = chartStyle;
     const dimensionMetricsMap = this.getFormDimensionMetricsMap();
     // Statistical dimension attribute, statistical value attribute, statistical value name.
     const dimensionField = fields.find(field => field.id === dimension) as Field;
@@ -185,7 +185,7 @@ export class EchartsLine extends EchartsBase {
       ...styleOption.commonOption,
       legend: { ...styleOption.commonOption.legend, data: legendNames },
       xAxis: { ...mainAxis },
-      yAxis: { ...subAxis },
+      yAxis: { ...subAxis, scale: excludeZeroPoint },
       series,
     };
 

--- a/src/model/echarts_scatter.ts
+++ b/src/model/echarts_scatter.ts
@@ -116,7 +116,7 @@ export class EchartsScatter extends EchartsBase {
     chartStyle: any,
   }) {
     const { dimension, metrics, metricsType, isSplitMultipleValue, seriesField, isFormatDatetime, datetimeFormatter } = chartStructure;
-    const { axisSortType, isCountNullValue } = chartStyle;
+    const { axisSortType, isCountNullValue, excludeZeroPoint } = chartStyle;
     const dimensionMetricsMap = this.getFormDimensionMetricsMap();
     const metricsField = fields.find(field => field.id === metrics.fieldId) as Field || {};
     const dimensionField = fields.find(field => field.id === dimension) as Field;
@@ -213,7 +213,7 @@ export class EchartsScatter extends EchartsBase {
     return {
       ...styleOption.commonOption,
       xAxis: { ...mainAxis },
-      yAxis: { ...subAxis },
+      yAxis: { ...subAxis, scale: excludeZeroPoint },
       series: [{
         ...styleOption.series,
         data: seriesData

--- a/src/ui_schema.tsx
+++ b/src/ui_schema.tsx
@@ -107,6 +107,11 @@ export const getUiSchema = (viewId: string) => {
           showTitle: false,
         },
       },
+      excludeZeroPoint: {
+        'ui:options': {
+          showTitle: false,
+        },
+      },
       theme: {
         'ui:widget': (props) => {
           return <ThemeSelect value={props.value} onChange={props.onChange} />;

--- a/strings.json
+++ b/strings.json
@@ -228,6 +228,14 @@
             "zh_CN": "显示维度空值",
             "en_US": "Show empty values"
         },
+        "exclude_zero_point": {
+            "zh_CN": "脱离零值比例",
+            "en_US": "Exclude zero point"
+        },
+        "exclude_zero_point_describle": {
+            "zh_CN": "脱离零值比例",
+            "en_US": "Exclude zero point"
+        },
         "show_smooth_line": {
             "zh_CN": "开启平滑曲线",
             "en_US": "Show smooth line"


### PR DESCRIPTION
Allow excluding zero point of Y-axis in scatter/column/line charts and of X-axis in bar charts using ECharts options [`xAxis.scale`](https://echarts.apache.org/en/option.html#xAxis.scale) and [`yAxis.scale`](https://echarts.apache.org/en/option.html#yAxis.scale).