### PR TITLE
feat: use option colors

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -902,3 +902,13 @@ export const sortSeries = (props: {
     max: 0,
   };
 };
+
+/**
+ * Retrieves the colors of options for a given field.
+ * @param {Field | undefined} field - The field object.
+ * @returns {Map<string, string>} - A map containing the names of options as keys and their respective color values as values.
+ */
+export const getOptionColors = (field: Field | undefined) => {
+  if (field?.entityType !== 'SingleSelect') return new Map();
+  return new Map(field.property.options.map(x => [x.name, x.color.value]));
+};

--- a/src/model/echarts_base.ts
+++ b/src/model/echarts_base.ts
@@ -290,6 +290,11 @@ export abstract class EchartsBase {
         type: 'boolean',
         description: t(Strings.exclude_zero_point_describle),
       },
+      useOptionColors: {
+        title: t(Strings.use_option_colors),
+        type: 'boolean',
+        description: t(Strings.use_option_colors_describle),
+      },
       theme: {
         title: t(Strings.select_theme_color),
         type: 'string',

--- a/src/model/echarts_column.ts
+++ b/src/model/echarts_column.ts
@@ -1,7 +1,7 @@
 import { Field, Record } from '@apitable/widget-sdk';
 import { ChartType, StackType } from "./interface";
 import { Strings, t } from "../i18n";
-import { formatterValue, maxRenderNum, processChartData, processRecords, sortSeries } from '../helper';
+import { formatterValue, getOptionColors, maxRenderNum, processChartData, processRecords, sortSeries } from '../helper';
 import { BarSeriesOption } from 'echarts';
 import { EchartsBase } from './echarts_base';
 
@@ -146,7 +146,7 @@ export class EchartsColumn extends EchartsBase {
     
     const isColumn = this.type === ChartType.EchartsColumn;
     const isPercent = this.stackType === StackType.Percent
-    const { axisSortType, isCountNullValue, excludeZeroPoint } = chartStyle;
+    const { axisSortType, isCountNullValue, excludeZeroPoint, useOptionColors } = chartStyle;
     const dimensionMetricsMap = this.getFormDimensionMetricsMap();
     const yKey = dimensionMetricsMap.metrics.key;
     // Statistical dimension attribute, statistical value attribute, statistical value name.
@@ -199,6 +199,7 @@ export class EchartsColumn extends EchartsBase {
       chartStyle,
       { noFormatMetric, metricsField, axisLength: axisNames.length }
     );
+    const colorMap = getOptionColors(seriesFieldInstance);
 
     const series: BarSeriesOption[] = [];
     if (axisSortType && seriesFieldInstance) {
@@ -216,11 +217,13 @@ export class EchartsColumn extends EchartsBase {
             [axisKey]: sereisItem[dataIndex],
             barWidth,
           } : {};
+          const itemStyle = { color: colorMap.get(item.sortKey) || '#000000' };
           series.push({
             ...styleOption.series,
             name: item.sortKey,
             data: [sereisItem],
             ...extraField,
+            ...(useOptionColors ? { itemStyle } : {}),
           });
         }
       }

--- a/src/model/echarts_line.ts
+++ b/src/model/echarts_line.ts
@@ -1,7 +1,7 @@
 import { LineSeriesOption } from 'echarts';
 import { ChartType, StackType } from "./interface";
 import { Strings, t } from '../i18n';
-import { formatterValue, maxRenderNum, processChartData, processRecords, sortSeries } from '../helper';
+import { formatterValue, getOptionColors, maxRenderNum, processChartData, processRecords, sortSeries } from '../helper';
 import { EchartsBase } from './echarts_base';
 import { Field } from '@apitable/widget-sdk';
 
@@ -103,7 +103,7 @@ export class EchartsLine extends EchartsBase {
     const { seriesField, dimension, metrics, metricsType, isSplitMultipleValue,
       isFormatDatetime: _isFormatDatetime, datetimeFormatter } = chartStructure;
     
-    const { axisSortType, isCountNullValue, excludeZeroPoint } = chartStyle;
+    const { axisSortType, isCountNullValue, excludeZeroPoint, useOptionColors } = chartStyle;
     const dimensionMetricsMap = this.getFormDimensionMetricsMap();
     // Statistical dimension attribute, statistical value attribute, statistical value name.
     const dimensionField = fields.find(field => field.id === dimension) as Field;
@@ -153,15 +153,18 @@ export class EchartsLine extends EchartsBase {
       metricsField,
       isColumn: true,
     });
+    const colorMap = getOptionColors(seriesFieldInstance);
 
     const series: LineSeriesOption[] = [];
     if (axisSortType && seriesFieldInstance) {
       for (let i = 0; i < sortedSeries.length; i++) {
         const item = sortedSeries[i];
+        const itemStyle = { color: colorMap.get(item.sortKey) || '#000000' };
         series.push({
           ...styleOption.series,
           name: item.sortKey,
           data: item.series.slice(0, maxRenderNum),
+          ...(useOptionColors ? { itemStyle } : {}),
         });
       }
     } else {

--- a/src/model/echarts_scatter.ts
+++ b/src/model/echarts_scatter.ts
@@ -28,11 +28,13 @@ export class EchartsScatter extends EchartsBase {
 
   getChartStyleFormJSON(fields: Field[]) {
     const dimensionMetricsMap = this.getFormDimensionMetricsMap();
+    const commonFormConfigJson = this.getCommonFormConfigJson();
+    delete commonFormConfigJson.useOptionColors;
     return {
       title: t(Strings.design_chart_style),
       type: 'object',
       properties: {
-        ...this.getCommonFormConfigJson(),
+        ...commonFormConfigJson,
         axisSortType: {
           title: t(Strings.chart_sort),
           type: 'object',

--- a/src/ui_schema.tsx
+++ b/src/ui_schema.tsx
@@ -112,6 +112,11 @@ export const getUiSchema = (viewId: string) => {
           showTitle: false,
         },
       },
+      useOptionColors: {
+        'ui:options': {
+          showTitle: false,
+        },
+      },
       theme: {
         'ui:widget': (props) => {
           return <ThemeSelect value={props.value} onChange={props.onChange} />;

--- a/strings.json
+++ b/strings.json
@@ -236,6 +236,14 @@
             "zh_CN": "脱离零值比例",
             "en_US": "Exclude zero point"
         },
+        "use_option_colors": {
+            "zh_CN": "使用选项颜色",
+            "en_US": "Use option colors"
+        },
+        "use_option_colors_describle": {
+            "zh_CN": "使用选项颜色",
+            "en_US": "Use option colors"
+        },
         "show_smooth_line": {
             "zh_CN": "开启平滑曲线",
             "en_US": "Show smooth line"


### PR DESCRIPTION
Allow using colors from `SingleSelect` fields in pie/column/line charts. In pie charts, the colors come from dimension fields; in column and line charts, the colors come from series fields.