### PR TITLE
fix: stacked line chart height display abnormality

### DIFF
--- a/src/model/echarts_column.ts
+++ b/src/model/echarts_column.ts
@@ -201,7 +201,7 @@ export class EchartsColumn extends EchartsBase {
     );
 
     const series: BarSeriesOption[] = [];
-    if (axisSortType && seriesFieldInstance) {
+    if (seriesFieldInstance) {
       const dataIndex = isColumn ? 0 : 1;
       const axisKey = isColumn ? 'xAxisIndex' : 'yAxisIndex';
       const isNormal = this.stackType === StackType.None;

--- a/src/model/echarts_line.ts
+++ b/src/model/echarts_line.ts
@@ -155,7 +155,7 @@ export class EchartsLine extends EchartsBase {
     });
 
     const series: LineSeriesOption[] = [];
-    if (axisSortType && seriesFieldInstance) {
+    if (seriesFieldInstance) {
       for (let i = 0; i < sortedSeries.length; i++) {
         const item = sortedSeries[i];
         series.push({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,7 @@ export const safeParseNumberOrText = (num : number | string | undefined, precisi
     return '';
   }
   return a.toFixed(precision);
-  
+};
 
 
 export const safeParseNumberOrTextWithSeparator = (num : number | string | undefined, precision: number) => {


### PR DESCRIPTION
Fixed issue where stacked/grouped charts displayed incorrect data heights when axis sorting was not configured. The series processing now properly groups data by dimension even without explicit sorting enabled.

Fixes vikadata/vikadata#11503