### PR TITLE
fix: stacked line chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,10 @@
     "react-custom-scrollbars": "^4.2.1",
     "styled-components": ">=5.2.1",
     "typescript": "4.1.2"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "not dead",
+    "not op_mini all"
+  ]
 }

--- a/src/model/echarts_line.ts
+++ b/src/model/echarts_line.ts
@@ -91,6 +91,7 @@ export class EchartsLine extends EchartsBase {
 
     if (this.stackType !== StackType.None) {
       styleOption.series.stack = 'total';
+      styleOption.series.areaStyle = {};
     }
 
     return styleOption;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,7 @@ export const safeParseNumberOrText = (num : number | string | undefined, precisi
     return '';
   }
   return a.toFixed(precision);
-  
+};
 
 
 export const safeParseNumberOrTextWithSeparator = (num : number | string | undefined, precision: number) => {


### PR DESCRIPTION
在「销售数据」表中使用堆叠折线图进行可视化时，发现部分数据折线高度明显异常，与实际数据不符。无论数据类型及展示字段如何设定，均会出现不同系列高度差异过大或总高度与实际合计不符的问题。

操作步骤
打开上述数据文件，进入「销售数据」表
添加或打开堆叠折线图表
选择存在多系列/组的字段进行堆叠展示
发现折线图不同系列高度明显异常，总高度偏离实际聚合值